### PR TITLE
Adjust makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ rplidar_sdk
 Release
 Debug
 *.o
-vil
+lidarvis
 
 # other
 *.user

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ LIBS=-lsfml-graphics -lsfml-window -lsfml-system -lrplidar_sdk
 SFML=${CURDIR}/sfml
 RPLIDAR=${CURDIR}/rplidar_sdk
 
-lidar: main app cloud cloud-grabbers cloud-writers guis scenarios
-	$(CXX) --output vil \
+lidarvis: main app cloud cloud-grabbers cloud-writers guis scenarios
+	$(CXX) --output lidarvis \
 	main.o \
 	app.o \
 	cloud.o \
@@ -40,4 +40,4 @@ scenarios: src/scenarios.cpp
 	$(CXX) $(CPPFLAGS) -c src/scenarios.cpp
 
 clean:
-	rm -f *.o src/*.o vil
+	rm -f *.o src/*.o lidarvis

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX=g++
-CPPFLAGS=-std=c++17 -DUSING_SFML -DUSING_RPLIDAR
-LIBS=-lsfml-graphics -lsfml-window -lsfml-system -lrplidar_sdk
+CPPFLAGS=-std=c++17 -DUSING_SFML
+LIBS=-lsfml-graphics -lsfml-window -lsfml-system
 
 SFML=${CURDIR}/sfml
 RPLIDAR=${CURDIR}/rplidar_sdk

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 CXX=g++
-CPPFLAGS=-std=c++17 -DUSING_SFML
-LIBS=-lsfml-graphics -lsfml-window -lsfml-system
+CPPFLAGS=-std=c++17 -DUSING_SFML -DUSING_RPLIDAR
+LIBS=-lsfml-graphics -lsfml-window -lsfml-system -lrplidar_sdk -pthread
 
 SFML=${CURDIR}/sfml
 RPLIDAR=${CURDIR}/rplidar_sdk
+
+OS=$(shell uname -s)
 
 lidarvis: main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios.o
 	$(CXX) --output lidarvis \
@@ -15,20 +17,20 @@ lidarvis: main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios
 	guis.o \
 	scenarios.o \
 	-L$(SFML)/lib \
-	-L$(RPLIDAR)/sdk/output/Darwin/Release \
+	-L$(RPLIDAR)/sdk/output/$(OS)/Release \
 	$(LIBS)
 
 main.o: src/main.cpp
-	$(CXX) $(CPPFLAGS) -c src/main.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src/hal
+	$(CXX) $(CPPFLAGS) -c src/main.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src
 
 app.o: src/app.cpp
-	$(CXX) $(CPPFLAGS) -c src/app.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src/hal
+	$(CXX) $(CPPFLAGS) -c src/app.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src
 
 cloud.o: src/cloud.cpp
 	$(CXX) $(CPPFLAGS) -c src/cloud.cpp
 
 cloud-grabbers.o: src/cloud-grabbers.cpp
-	$(CXX) $(CPPFLAGS) -c src/cloud-grabbers.cpp -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src/hal
+	$(CXX) $(CPPFLAGS) -c src/cloud-grabbers.cpp -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src
 
 cloud-writers.o: src/cloud-writers.cpp
 	$(CXX) $(CPPFLAGS) -c src/cloud-writers.cpp 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 CXX=g++
-CPPFLAGS=-std=c++17 -DUSING_SFML
-LIBS=-lsfml-graphics -lsfml-window -lsfml-system
+CPPFLAGS=-std=c++17 -DUSING_SFML -DUSING_RPLIDAR
+LIBS=-lsfml-graphics -lsfml-window -lsfml-system -lrplidar_sdk
 
 SFML=${CURDIR}/sfml
+RPLIDAR=${CURDIR}/rplidar_sdk
 
 lidar: main app cloud cloud-grabbers cloud-writers guis scenarios
 	$(CXX) --output vil \
@@ -14,19 +15,20 @@ lidar: main app cloud cloud-grabbers cloud-writers guis scenarios
 	guis.o \
 	scenarios.o \
 	-L$(SFML)/lib \
+	-L$(RPLIDAR)/sdk/output/Darwin/Release \
 	$(LIBS)
 
-app: src/app.cpp
-	$(CXX) $(CPPFLAGS) -c src/app.cpp -I$(SFML)/include
-
 main: src/main.cpp
-	$(CXX) $(CPPFLAGS) -c src/main.cpp -I$(SFML)/include
+	$(CXX) $(CPPFLAGS) -c src/main.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src/hal
+
+app: src/app.cpp
+	$(CXX) $(CPPFLAGS) -c src/app.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src/hal
 
 cloud: src/cloud.cpp
-	$(CXX) $(CPPFLAGS) -c src/cloud.cpp 
+	$(CXX) $(CPPFLAGS) -c src/cloud.cpp
 
 cloud-grabbers: src/cloud-grabbers.cpp
-	$(CXX) $(CPPFLAGS) -c src/cloud-grabbers.cpp 
+	$(CXX) $(CPPFLAGS) -c src/cloud-grabbers.cpp -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src/hal
 
 cloud-writers: src/cloud-writers.cpp
 	$(CXX) $(CPPFLAGS) -c src/cloud-writers.cpp 

--- a/Makefile
+++ b/Makefile
@@ -4,42 +4,38 @@ LIBS=-lsfml-graphics -lsfml-window -lsfml-system
 
 SFML=${CURDIR}/sfml
 
-lol:
-	@echo "lol"
-	ls $(SFML)/include/SFML
-
-lidar: lidar/app.o lidar/cloud-grabbers.o lidar/cloud-writers.o lidar/cloud.o lidar/guis.o lidar/main.o lidar/scenarios.o
+lidar: main app cloud cloud-grabbers cloud-writers guis scenarios
 	$(CXX) --output vil \
-	lidar/app.o \
-	lidar/cloud-grabbers.o \
-	lidar/cloud-writers.o \
-	lidar/cloud.o \
-	lidar/guis.o \
-	lidar/main.o \
-	lidar/scenarios.o \
+	main.o \
+	app.o \
+	cloud.o \
+	cloud-grabbers.o \
+	cloud-writers.o \
+	guis.o \
+	scenarios.o \
 	-L$(SFML)/lib \
 	$(LIBS)
 
-app.o: lidar/app.cpp
-	$(CXX) $(CPPFLAGS) -c lidar/app.cpp -I$(SFML)/include
+app: src/app.cpp
+	$(CXX) $(CPPFLAGS) -c src/app.cpp -I$(SFML)/include
 
-cloud-grabbers.o: lidar/cloud-grabbers.cpp
-	$(CXX) $(CPPFLAGS) -c lidar/cloud-grabbers.cpp -I$(SFML)/include
+main: src/main.cpp
+	$(CXX) $(CPPFLAGS) -c src/main.cpp -I$(SFML)/include
 
-cloud-writers.o: lidar/cloud-writers.cpp
-	$(CXX) $(CPPFLAGS) -c lidar/cloud-writers.cpp -I$(SFML)/include
+cloud: src/cloud.cpp
+	$(CXX) $(CPPFLAGS) -c src/cloud.cpp 
 
-cloud.o: lidar/cloud.cpp
-	$(CXX) $(CPPFLAGS) -c lidar/cloud.cpp -I$(SFML)/include
+cloud-grabbers: src/cloud-grabbers.cpp
+	$(CXX) $(CPPFLAGS) -c src/cloud-grabbers.cpp 
 
-guis.o: lidar/guis.cpp
-	$(CXX) $(CPPFLAGS) -c lidar/guis.cpp -I$(SFML)/include
+cloud-writers: src/cloud-writers.cpp
+	$(CXX) $(CPPFLAGS) -c src/cloud-writers.cpp 
 
-main.o: lidar/main.cpp
-	$(CXX) $(CPPFLAGS) -c lidar/main.cpp -I$(SFML)/include
+guis: src/guis.cpp
+	$(CXX) $(CPPFLAGS) -c src/guis.cpp -I$(SFML)/include
 
-scenarios.o: lidar/scenarios.cpp
-	$(CXX) $(CPPFLAGS) -c lidar/scenarios.cpp -I$(SFML)/include
+scenarios: src/scenarios.cpp
+	$(CXX) $(CPPFLAGS) -c src/scenarios.cpp
 
 clean:
-	rm -f *.o lidar/*.o vil
+	rm -f *.o src/*.o vil

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LIBS=-lsfml-graphics -lsfml-window -lsfml-system
 SFML=${CURDIR}/sfml
 RPLIDAR=${CURDIR}/rplidar_sdk
 
-lidarvis: main app cloud cloud-grabbers cloud-writers guis scenarios
+lidarvis: main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios.o
 	$(CXX) --output lidarvis \
 	main.o \
 	app.o \
@@ -18,25 +18,25 @@ lidarvis: main app cloud cloud-grabbers cloud-writers guis scenarios
 	-L$(RPLIDAR)/sdk/output/Darwin/Release \
 	$(LIBS)
 
-main: src/main.cpp
+main.o: src/main.cpp
 	$(CXX) $(CPPFLAGS) -c src/main.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src/hal
 
-app: src/app.cpp
+app.o: src/app.cpp
 	$(CXX) $(CPPFLAGS) -c src/app.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src/hal
 
-cloud: src/cloud.cpp
+cloud.o: src/cloud.cpp
 	$(CXX) $(CPPFLAGS) -c src/cloud.cpp
 
-cloud-grabbers: src/cloud-grabbers.cpp
+cloud-grabbers.o: src/cloud-grabbers.cpp
 	$(CXX) $(CPPFLAGS) -c src/cloud-grabbers.cpp -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src/hal
 
-cloud-writers: src/cloud-writers.cpp
+cloud-writers.o: src/cloud-writers.cpp
 	$(CXX) $(CPPFLAGS) -c src/cloud-writers.cpp 
 
-guis: src/guis.cpp
+guis.o: src/guis.cpp
 	$(CXX) $(CPPFLAGS) -c src/guis.cpp -I$(SFML)/include
 
-scenarios: src/scenarios.cpp
+scenarios.o: src/scenarios.cpp
 	$(CXX) $(CPPFLAGS) -c src/scenarios.cpp
 
 clean:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ At the moment, ready-to-run binaries are only available for Windows. Have a look
 
 ### Linux, MacOS
 
-TODO
+1. Get SFML: `$ ./install_sfml --verbose`
+2. Get RPLIDAR_SDK: `$ ./install_rplidar --verbose`
+3. Compile and link everything `$ make lidarvis`
 
 ### Windows
 
@@ -102,7 +104,7 @@ The project is developed using Visual Studio on Windows. There are some addition
 **\*** `lidar.sln` uses several project property files (*rplidar.props*, *sfml-debug.props*, *sfml-release.props*) which consist of relative include and library paths to RPLIDAR SDK and SFML, and define macros enabling sections of code that requires the specified dependencies (`USING_RPLIDAR`, `USING_SFML`). For example, if you remove SFML property files from the project, a compiler won't be looking for SFML and finally it will build the program without the SFML GUI. You can do the same with RPLIDAR, so you won't be able to receive data from it.
 
 ## Usage
-If you successfully downloaded or compiled LV, you are able to start some scanning and visualizing. The program can be controlled via command line in such a way:
+When you have the `lidarvis` executable , you are able to start some scanning and visualizing. The program can be controlled via command line in such a way:
 
 ```
 lidar [options]

--- a/install_rplidar
+++ b/install_rplidar
@@ -29,17 +29,6 @@ _log "install_rplidar: cloning rplidar_sdk..."
 git clone "$rplidar_url" &>/dev/null
 _log "ok\n"
 
-# rplidar_sdk/sdk/sdk/include/rplidar.h includes "hal/types.h"m
-# but it cannot be found with the default rplidar_sdk project structure.
-# (It's probably some bug made by the rplidar_sdk authors)
-# That's why we're copying the hal folder (under "rplidar_sdk/sdk/sdk/src/hal")
-# to rplidar_sdk/sdk/sdk/include/hal.
-# Thanks to this sly move, the linker will be able to find it.
-
-_log "install_rplidar: moving the hal directory..."
-cp -r rplidar_sdk/sdk/sdk/src/hal rplidar_sdk/sdk/sdk/include
-_log "ok\n"
-
 _log "install_rplidar: making the sdk..."
 cd rplidar_sdk/sdk && make &>/dev/null
 _log "ok\n"

--- a/install_rplidar
+++ b/install_rplidar
@@ -20,9 +20,28 @@ fi
 
 rplidar_url="https://github.com/Slamtec/rplidar_sdk.git"
 
+if [ -d rplidar_sdk ]; then
+  printf "install_rplidar: rplidar_sdk directory already exists\n"
+  exit 1
+fi
 
 _log "install_rplidar: cloning rplidar_sdk..."
 git clone "$rplidar_url" &>/dev/null
+_log "ok\n"
+
+# rplidar_sdk/sdk/sdk/include/rplidar.h includes "hal/types.h"m
+# but it cannot be found with the default rplidar_sdk project structure.
+# (It's probably some bug made by the rplidar_sdk authors)
+# That's why we're copying the hal folder (under "rplidar_sdk/sdk/sdk/src/hal")
+# to rplidar_sdk/sdk/sdk/include/hal.
+# Thanks to this sly move, the linker will be able to find it.
+
+_log "install_rplidar: moving the hal directory..."
+cp -r rplidar_sdk/sdk/sdk/src/hal rplidar_sdk/sdk/sdk/include
+_log "ok\n"
+
+_log "install_rplidar: making the sdk..."
+cd rplidar_sdk/sdk && make &>/dev/null
 _log "ok\n"
 
 printf "install_rplidar: done\n"

--- a/install_sfml
+++ b/install_sfml
@@ -24,6 +24,10 @@ fi
 if [ -d "sfml" ]; then
   printf "install_sfml: sfml directory already exists\n"
   exit 1
+else
+  printf "install_sfml: creating sfml directory..."
+  mkdir sfml
+  printf "ok\n"
 fi
 
 
@@ -44,14 +48,13 @@ case "$(uname -s)" in
 esac
 
 _log "install_sfml: downloading SFML..."
-curl -Ss "$download_url" > sfml.zip
+curl -Ss "$download_url" > sfml.tar.gz
 _log "ok\n"
 
 _log "install_sfml: extracting SFML..."
-tar -xf sfml.zip
+tar -xzf sfml.tar.gz --strip-components 1 -C sfml
 _log "ok\n"
 
-rm sfml.zip
+rm sfml.tar.gz
 
 printf "install_sfml: done\n"
-printf 'install_sfml: now you must rename the extracted directory to "sfml"\n'


### PR DESCRIPTION
Adjusted makefile to match the new directory structure introduced in #21 

main changes:
- renamed main target to `lidarvis`
- renamed the generated executable name to `lidarvis`

# Status

### "pure" build
- [x] Linux
- [x] macOS
- [?] Windows (probably, needs to be checked)

### with `USING_SFML` builds
- [x] Linux
- [ ] macOS - executable is generated, but it crashes immediately after running with the following error message:
```
dyld: Library not loaded: @rpath/libsfml-graphics.2.5.dylib
  Referenced from: /Users/bartek/dev/cpp/lidar-visualizations/./lidarvis
  Reason: image not found
[1]    4982 abort      ./lidarvis
```
- [ ] Windows (probably, needs to be checked)

### with `USING_RPLIDAR`
- [ ] Linux - g++ doesn't compile rplidar_sdk because it finds errors in the library's source code (`rplidar_sdk/sdk/sdk/include/rplidar_driver.h` file).
    To see those errors, `make` in `rplidar_sdk/sdk`. This is very strange because it __was__ working.
- [x] macOS
- [ ] Windows (probably, needs to be checked)

