### PR TITLE
Improve build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# tools
+.vs
+.vscode
+
+# dependency dirs
+sfml
+rplidar_sdk
+
+# generated stuff
+Release
+Debug
+*.o
+lidarvis
+
+# other
+*.user
+*.xcf
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:latest
+
+RUN apk --no-cache add curl
+
+COPY . /lidar-vis
+
+WORKDIR /lidar-vis
+
+RUN ./install_sfml
+
+RUN ./install_rplidar
+
+RUN make
+
+RUN LD_LIBRARY_PATH=/lidar-vis/sfml/lib
+
+CMD [ "./lidarvis" "-fs" "datasets/series/pokoj-podnoszenie-gora-dol.txt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM alpine:latest
+FROM archlinux:latest
 
-RUN apk --no-cache add curl
+RUN pacman -Syyu --noconfirm
+
+RUN pacman -S --noconfirm sed git gcc make
 
 COPY . /lidar-vis
 
@@ -14,4 +16,4 @@ RUN make
 
 RUN LD_LIBRARY_PATH=/lidar-vis/sfml/lib
 
-CMD [ "./lidarvis" "-fs" "datasets/series/pokoj-podnoszenie-gora-dol.txt"]
+CMD [ "./lidarvis" "--gui", "0", "--file" "datasets/knei-1.txt" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN ./install_sfml
 
 RUN ./install_rplidar
 
-RUN make
+RUN make lidarvis
 
 RUN LD_LIBRARY_PATH=/lidar-vis/sfml/lib
 

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,23 @@ RPLIDAR := ${CURDIR}/rplidar_sdk
 
 OS=$(shell uname -s)
 
+SFML_INCLUDES :=
+RPLIDAR_INCLUDES :=
+
 ifeq ($(USE_SFML),true)
 $(info "compiling with sfml")
 CPPFLAGS += -DUSING_SFML
 LIBS += -lsfml-graphics -lsfml-window -lsfml-system
+SFML_INCLUDES += -I$(SFML)/include
+SFML_LIBS := -L$(SFML)/lib
 endif
 
 ifeq ($(USE_RPLIDAR),true)
 $(info "compiling with rplidar_sdk")
 CPPFLAGS += -DUSING_RPLIDAR
 LIBS += -lrplidar_sdk -pthread
+RPLIDAR_INCLUDES += -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src
+RPLIDAR_LIBS := -L$(RPLIDAR)/sdk/output/$(OS)/Release
 endif
 
 lidarvis: main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios.o
@@ -28,27 +35,27 @@ lidarvis: main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios
 	cloud-writers.o \
 	guis.o \
 	scenarios.o \
-	-L$(SFML)/lib \
-	-L$(RPLIDAR)/sdk/output/$(OS)/Release \
+	$(SFML_LIBS) \
+	$(RPLIDAR_LIBS) \
 	$(LIBS)
 
 main.o: src/main.cpp
-	$(CXX) $(CPPFLAGS) -c src/main.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src
+	$(CXX) $(CPPFLAGS) -c src/main.cpp $(SFML_INCLUDES) $(RPLIDAR_INCLUDES)
 
 app.o: src/app.cpp
-	$(CXX) $(CPPFLAGS) -c src/app.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src
+	$(CXX) $(CPPFLAGS) -c src/app.cpp $(SFML_INCLUDES) $(RPLIDAR_INCLUDES)
 
 cloud.o: src/cloud.cpp
 	$(CXX) $(CPPFLAGS) -c src/cloud.cpp
 
 cloud-grabbers.o: src/cloud-grabbers.cpp
-	$(CXX) $(CPPFLAGS) -c src/cloud-grabbers.cpp -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src
+	$(CXX) $(CPPFLAGS) -c src/cloud-grabbers.cpp $(RPLIDAR_INCLUDES)
 
 cloud-writers.o: src/cloud-writers.cpp
 	$(CXX) $(CPPFLAGS) -c src/cloud-writers.cpp 
 
 guis.o: src/guis.cpp
-	$(CXX) $(CPPFLAGS) -c src/guis.cpp -I$(SFML)/include
+	$(CXX) $(CPPFLAGS) -c src/guis.cpp $(SFML_INCLUDES)
 
 scenarios.o: src/scenarios.cpp
 	$(CXX) $(CPPFLAGS) -c src/scenarios.cpp

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
+# Explicitly define all variables that are used (even the "standard variables")
+# Usage:
+# To compile without dependencies: make lidarvis
+# To compile with SFML: make lidarvis USE_SFML=true
+# To compile with SFML and rplidar_sdk: make lidarvis USE_RPLIDAR=true
+# To compile with SFML and rplidar_sdk: make lidarvis USE_SFML=true USE_RPLIDAR=true
+
 CXX := g++
 CPPFLAGS := -std=c++17
 LIBS :=
+LDFLAGS :=
 
 SFML := ${CURDIR}/sfml
 RPLIDAR := ${CURDIR}/rplidar_sdk
@@ -15,7 +23,7 @@ $(info "compiling with sfml")
 CPPFLAGS += -DUSING_SFML
 LIBS += -lsfml-graphics -lsfml-window -lsfml-system
 SFML_INCLUDES += -I$(SFML)/include
-SFML_LIBS := -L$(SFML)/lib
+LDFLAGS += -L$(SFML)/lib
 endif
 
 ifeq ($(USE_RPLIDAR),true)
@@ -23,7 +31,7 @@ $(info "compiling with rplidar_sdk")
 CPPFLAGS += -DUSING_RPLIDAR
 LIBS += -lrplidar_sdk -pthread
 RPLIDAR_INCLUDES += -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src
-RPLIDAR_LIBS := -L$(RPLIDAR)/sdk/output/$(OS)/Release
+LDFLAGS += -L$(RPLIDAR)/sdk/output/$(OS)/Release
 endif
 
 lidarvis: main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios.o
@@ -35,8 +43,7 @@ lidarvis: main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios
 	cloud-writers.o \
 	guis.o \
 	scenarios.o \
-	$(SFML_LIBS) \
-	$(RPLIDAR_LIBS) \
+	$(LDFLAGS) \
 	$(LIBS)
 
 main.o: src/main.cpp

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,25 @@
-CXX=g++
-CPPFLAGS=-std=c++17
-LIBS=
+CXX := g++
+CPPFLAGS := -std=c++17
+LIBS :=
 
-SFML=${CURDIR}/sfml
-RPLIDAR=${CURDIR}/rplidar_sdk
+SFML := ${CURDIR}/sfml
+RPLIDAR := ${CURDIR}/rplidar_sdk
 
 OS=$(shell uname -s)
 
-lidarvis: handle_sfml handle_rplidar main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios.o
+ifeq ($(USE_SFML),true)
+$(info "compiling with sfml")
+CPPFLAGS += -DUSING_SFML
+LIBS += -lsfml-graphics -lsfml-window -lsfml-system
+endif
+
+ifeq ($(USE_RPLIDAR),true)
+$(info "compiling with rplidar_sdk")
+CPPFLAGS += -DUSING_RPLIDAR
+LIBS += -lrplidar_sdk -pthread
+endif
+
+lidarvis: main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios.o
 	$(CXX) --output lidarvis \
 	main.o \
 	app.o \
@@ -19,23 +31,6 @@ lidarvis: handle_sfml handle_rplidar main.o app.o cloud.o cloud-grabbers.o cloud
 	-L$(SFML)/lib \
 	-L$(RPLIDAR)/sdk/output/$(OS)/Release \
 	$(LIBS)
-
-handle_sfml:
-ifeq ($(USING_SFML),true)
-	@echo "compiling with sfml"
-	CPPFLAGS+=-DUSING_SFML
-	LIBS+=-lsfml-graphics
-	LIBS+=-lsfml-window 
-	LIBS+=-lsfml-system 
-	LIBS+=-pthread
-endif
-
-handle_rplidar:
-ifeq ($(USING_RPLIDAR),true)
-	@echo "compiling with rplidar_sdk"
-	CPPFLAGS+=-DUSING_RPLIDAR
-	LIBS+=-lrplidar_sdk
-endif
 
 main.o: src/main.cpp
 	$(CXX) $(CPPFLAGS) -c src/main.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 CXX=g++
-CPPFLAGS=-std=c++17 -DUSING_SFML -DUSING_RPLIDAR
-LIBS=-lsfml-graphics -lsfml-window -lsfml-system -lrplidar_sdk -pthread
+CPPFLAGS=-std=c++17
+LIBS=
 
 SFML=${CURDIR}/sfml
 RPLIDAR=${CURDIR}/rplidar_sdk
 
 OS=$(shell uname -s)
 
-lidarvis: main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios.o
+lidarvis: handle_sfml handle_rplidar main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios.o
 	$(CXX) --output lidarvis \
 	main.o \
 	app.o \
@@ -19,6 +19,23 @@ lidarvis: main.o app.o cloud.o cloud-grabbers.o cloud-writers.o guis.o scenarios
 	-L$(SFML)/lib \
 	-L$(RPLIDAR)/sdk/output/$(OS)/Release \
 	$(LIBS)
+
+handle_sfml:
+ifeq ($(USING_SFML),true)
+	@echo "compiling with sfml"
+	CPPFLAGS+=-DUSING_SFML
+	LIBS+=-lsfml-graphics
+	LIBS+=-lsfml-window 
+	LIBS+=-lsfml-system 
+	LIBS+=-pthread
+endif
+
+handle_rplidar:
+ifeq ($(USING_RPLIDAR),true)
+	@echo "compiling with rplidar_sdk"
+	CPPFLAGS+=-DUSING_RPLIDAR
+	LIBS+=-lrplidar_sdk
+endif
 
 main.o: src/main.cpp
 	$(CXX) $(CPPFLAGS) -c src/main.cpp -I$(SFML)/include -I$(RPLIDAR)/sdk/sdk/include -I$(RPLIDAR)/sdk/sdk/src

--- a/install_rplidar
+++ b/install_rplidar
@@ -29,8 +29,13 @@ _log "install_rplidar: cloning rplidar_sdk..."
 git clone "$rplidar_url" &>/dev/null
 _log "ok\n"
 
+# Disable strange warnings that arise...sometimes
+if [ $(uname -s) = "Linux" ]; then
+  `sed -i '57iCXXFLAGS += -Wno-narrowing' rplidar_sdk/sdk/mak_def.inc`
+fi
+
 _log "install_rplidar: making the sdk..."
-cd rplidar_sdk/sdk && make &>/dev/null
+cd rplidar_sdk/sdk && make CXXFLAGS=-Wno-narrowing &>/dev/null
 _log "ok\n"
 
 printf "install_rplidar: done\n"

--- a/install_rplidar
+++ b/install_rplidar
@@ -25,17 +25,19 @@ if [ -d rplidar_sdk ]; then
   exit 1
 fi
 
-_log "install_rplidar: cloning rplidar_sdk..."
+_log "install_rplidar: cloning the sdk..."
 git clone "$rplidar_url" &>/dev/null
 _log "ok\n"
 
 # Disable strange warnings that arise...sometimes
 if [ $(uname -s) = "Linux" ]; then
-  `sed -i '57iCXXFLAGS += -Wno-narrowing' rplidar_sdk/sdk/mak_def.inc`
+  printf "install_rplidar: Linux host detected, applying ugly fix..."
+  sed -i '57iCXXFLAGS += -Wno-narrowing' rplidar_sdk/sdk/mak_def.inc
+  printf "ok\n"
 fi
 
 _log "install_rplidar: making the sdk..."
-cd rplidar_sdk/sdk && make CXXFLAGS=-Wno-narrowing &>/dev/null
+cd rplidar_sdk/sdk && make &>/dev/null
 _log "ok\n"
 
 printf "install_rplidar: done\n"


### PR DESCRIPTION
## Make usage
> only Unix-like systems

- To compile without dependencies: `make lidarvis`
- To compile with SFML: `make lidarvis USE_SFML=true`
- To compile with SFML and rplidar_sdk: `make lidarvis USE_RPLIDAR=true`
- To compile with SFML and rplidar_sdk: `make lidarvis USE_SFML=true USE_RPLIDAR=true`

## Docker image
available [here](https://hub.docker.com/repository/docker/bartekpacia/lidarvis)

