### PR TITLE
Add simple GitHub Action

### DIFF
--- a/.github/release_base.yml
+++ b/.github/release_base.yml
@@ -1,0 +1,21 @@
+name: Build Linux executable
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install sfml
+      run: ./install_sfml
+    - name: install rplidar_sdk
+      run: ./install_rplidar
+    - name: make
+      run: make


### PR DESCRIPTION
**When**:
- there is a new commit on the `main` branch

**Then**:
- this GH Action will build a new "base executable" (i.e without  `SFML` and `rplidar_sdk`) and upload it to the Releases tab 